### PR TITLE
Install Cake 0.30.0 by default and fix unquoted args being treated as scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ command -v dotnet >/dev/null 2>&1 || {
 
 SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOOLS_DIR=${TOOLS_DIR:-"${SCRIPT_ROOT}/tools"}
-CAKE_VERSION=${CAKE_VERSION:-0.28.0}
+CAKE_VERSION=${CAKE_VERSION:-0.30.0}
 CAKE_NETCOREAPP_VERSION=${CAKE_NETCOREAPP_VERSION:-2.0}
 
 mkdir -p "${TOOLS_DIR}"
@@ -73,5 +73,15 @@ fi
 if $SHOW_VERSION; then
     exec dotnet "$CAKE_DLL" -version
 else
-    exec dotnet "$CAKE_DLL" "${SCRIPT}" "-verbosity=${VERBOSITY}" "-configuration=${CONFIGURATION}" "-target=${TARGET}" "${DRYRUN}" "${SCRIPT_ARGUMENTS[@]-}"
+    cakecmd="dotnet \"${CAKE_DLL}\" \"${SCRIPT}\" \"-verbosity=${VERBOSITY}\" \"-configuration=${CONFIGURATION}\" \"-target=${TARGET}\""
+
+    if [ ! -z "${DRYRUN}" ]; then
+        cakecmd+=" \"${DRYRUN}\""
+    fi
+
+    if [ "${#SCRIPT_ARGUMENTS[@]}" -gt 0 ]; then
+        cakecmd+=" \"${SCRIPT_ARGUMENTS[*]}\""
+    fi
+
+    eval "$(printf '%b\n' "${cakecmd}")"
 fi

--- a/tools/cake.csproj
+++ b/tools/cake.csproj
@@ -1,3 +1,1 @@
-<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>netcoreapp2.0</TargetFramework></PropertyGroup><ItemGroup>
-  <PackageReference Include="Cake.CoreCLR" Version="0.28.0" />
-</ItemGroup></Project>
+<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>netcoreapp2.0</TargetFramework></PropertyGroup></Project>


### PR DESCRIPTION
Cake has started treating empty args as build script paths, causing an exception to be thrown. We now only include optional args if they're set (like powershell). This should probably be reported upstream as I don't see this listed in the release notes.

Fixes #4 